### PR TITLE
Upgrade to kvm-bindings v0.4.0-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0-1]
+
+- [upstream] vmm-sys-utils dependency bumped to v0.8.0
+- versionize dependency bumped to v0.1.6
+
 ## [0.3.0-3]
 
 ### Changed
@@ -22,6 +27,13 @@
 - [upstream] Enabled `fam-wrappers` support on arm and arm64.
 - [upstream] Added fam-wrapper for the arm specific `kvm_reg_list` struct.
 
+## [0.3.0]
+
+### Added
+
+- Added versioning support for kvm bindings structures used
+  in VM serialization on x86_64.
+
 ## [0.2.0-2]
 
 ### Changed
@@ -31,11 +43,6 @@
 ## [0.2.0-1]
 
 Built on top of upstream rust-vmm/kvm-bindings v0.2.0.
-
-### Added
-
-- Added versioning support for kvm bindings structures used
-  in VM serialization on x86_64.
 
 ## [0.2.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-bindings"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 description = "Rust FFI bindings to KVM generated using bindgen."
 repository = "https://github.com/rust-vmm/kvm-bindings"
@@ -14,7 +14,7 @@ kvm-v4_20_0 = []
 fam-wrappers = ["vmm-sys-util"]
 
 [dependencies]
-vmm-sys-util = { version = ">=0.2.0", optional = true }
+vmm-sys-util = { version = ">=0.8.0", optional = true }
 
-versionize = { version = ">=0.1.4" }
+versionize = { version = ">=0.1.6" }
 versionize_derive = { version = ">=0.1.3" }

--- a/README.md
+++ b/README.md
@@ -2,13 +2,22 @@
 [![Crates.io](https://img.shields.io/crates/v/kvm-bindings.svg)](https://crates.io/crates/kvm-bindings)
 ![](https://img.shields.io/crates/l/kvm-bindings.svg)
 # kvm-bindings
-Rust FFI bindings to KVM generated using
+Rust FFI bindings to KVM, generated using
 [bindgen](https://crates.io/crates/bindgen). It currently has support for the
 following target architectures:
 - x86
 - x86_64
 - arm
 - arm64
+
+The bindings exported by this crate are statically generated using header files
+associated with a specific kernel version, and are not automatically synced with
+the kernel version running on a particular host. The user must ensure that
+specific structures, members, or constants are supported and valid for the
+kernel version they are using. For example, the `immediate_exit` field from the
+`kvm_run` structure is only meaningful if the `KVM_CAP_IMMEDIATE_EXIT`
+capability is available. Using invalid fields or features may lead to undefined
+behaviour.
 
 # Usage
 First, add the following to your `Cargo.toml`:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ behaviour.
 # Usage
 First, add the following to your `Cargo.toml`:
 ```toml
-kvm-bindings = "0.1"
+kvm-bindings = "0.4"
 ```
 Next, add this to your crate root:
 ```rust
@@ -32,7 +32,7 @@ By default `kvm-bindings` will export a wrapper over the latest available kernel
 version (4.20), but you can select a different version by specifying it in your
 toml:
 ```toml
-kvm-bindings = { version = "0.1", features = ["kvm_v4_20_0"]}
+kvm-bindings = { version = "0.4", features = ["kvm_v4_20_0"]}
 ```
 Bindings are generated for each specific Linux kernel version based on the enabled
 crate features as follows:
@@ -44,7 +44,7 @@ a Flexible Array Member in their definition.
 These safe wrappers can be used if the `fam-wrappers` feature is enabled for
 this crate. Example:
 ```toml
-kvm-bindings = { version = "0.1", features = ["kvm_v4_20_0", "fam-wrappers"]}
+kvm-bindings = { version = "0.4", features = ["kvm_v4_20_0", "fam-wrappers"]}
 ```
 
 # Dependencies

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 67.2,
+  "coverage_score": 60.9,
   "exclude_path": "",
   "crate_features": "fam-wrappers"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,0 +1,5 @@
+{
+  "coverage_score": 50.8,
+  "exclude_path": "",
+  "crate_features": "fam-wrappers"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Rust FFI bindings to KVM, generated using [bindgen](https://crates.io/crates/bindgen).
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
*Description of changes:*

Cherry-picked changes from upstream and released v0.4.0-1.

The highlight of this is the upgrade of `vmm-sys-util` to v0.8.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
