### PR TITLE
Update vmm-sys-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 fam-wrappers = ["vmm-sys-util"]
 
 [dependencies]
-vmm-sys-util = { version = ">=0.8.0", optional = true }
+vmm-sys-util = { version = "0.11.0", optional = true }
 
-versionize = { version = ">=0.1.6" }
-versionize_derive = { version = ">=0.1.3" }
+versionize = { version = "0.1.6" }
+versionize_derive = { version = "0.1.4" }


### PR DESCRIPTION
*Description of changes:*

Updates vmm-sys-util and changes our requirement specification to caret requirements.

Crate not affected by any breaking changes from vmm-sys-util 0.8.0->0.11.0.

PR works with https://github.com/firecracker-microvm/firecracker/pull/3252, which has to be merged first

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
