### PR TITLE
Consume dependency fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.0-2]
+
+- [upstream] Use caret requirements for specifying dependencies and
+             update vmm-sys-util to 0.11.0
+
 ## [0.5.0-1]
 
 - [upstream] updated kvm-bindings to version 0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 fam-wrappers = ["vmm-sys-util"]
 
 [dependencies]
-vmm-sys-util = { version = ">=0.8.0", optional = true }
+vmm-sys-util = { version = "0.11.0", optional = true }
 
 versionize = { version = ">=0.1.6" }
 versionize_derive = { version = ">=0.1.3" }


### PR DESCRIPTION
Cherry-picks an upstream commit to update vmm-sys-util to 0.11.0 and to use caret requirements for specifying dependencies (see https://github.com/rust-vmm/community/issues/136 for details).

Bumps the version to 0.5.0-2 (after merging a tag will have to be crates so that firecracker can consume the new version)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
